### PR TITLE
add support for composer.json

### DIFF
--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -71,6 +71,10 @@ module.exports = ProjectView =
         pkgFile = path.join root.getPath(), '.bower.json'
         return @getPropertyFromPackageJson(pkgFile, 'name').then (value) ->
           {root: root, name: value}
+      else if files.indexOf('composer.json') isnt -1
+        pkgFile = path.join root.getPath(), 'composer.json'
+        return @getPropertyFromPackageJson(pkgFile, 'name').then (value) ->
+          {root: root, name: value}
       else
         {root: root, name: null}
 


### PR DESCRIPTION
This pull adds support for reading the project name from the 'name' property of a composer.json file, used in modern PHP projects.
