### PR TITLE
Fix #22 & #23

### DIFF
--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -100,11 +100,11 @@ module.exports = ProjectView =
         @projectMap[rootPath] = project
         # Bind for name changes and activate watcher
         project.onDidChange 'name', ({root, name}) =>
-          @updateProjectRoot(root, name)
+          @updateProjectRoot(root.getPath(), name)
         project.watch()
       # Get the project name and update the tree view
       project.findProjectName().then ({root, name}) =>
-        @updateProjectRoot(root, name)
+        @updateProjectRoot(root.getPath(), name)
       .catch (error) ->
         console.error(error, error.stack)
     # Clean up removed projects
@@ -119,7 +119,7 @@ module.exports = ProjectView =
   findRootByPath: (rootPath) ->
     for root in @treeView.roots
       if rootPath is root.getPath()
-        return rootPath
+        return root
 
   clearRoots: ->
     roots = @treeView.roots
@@ -134,7 +134,8 @@ module.exports = ProjectView =
       delete root.directoryPath
     @projectMap = {}
 
-  updateProjectRoot: (root, name) ->
+  updateProjectRoot: (rootPath, name) ->
+    root = @findRootByPath(rootPath)
     if name?
       root.directoryName.textContent = name
       root.directoryName.classList.add('project-view')

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -102,13 +102,15 @@ module.exports = ProjectView =
         project.onDidChange 'name', ({root, name}) =>
           @updateProjectRoot(root.getPath(), name)
         project.watch()
-      
-      @updateProjectRoot(root.getPath(), project.projectName) if project.projectName
-      # Get the project name and update the tree view
-      project.findProjectName().then ({root, name}) =>
-        @updateProjectRoot(root.getPath(), name)
-      .catch (error) ->
-        console.error(error, error.stack)
+      if project.projectName
+        # Project name has been already cached
+        @updateProjectRoot(rootPath, project.projectName)
+      else
+        # Find the project name as it hasn't been cached yet
+        project.findProjectName().then ({_, name}) =>
+          @updateProjectRoot(rootPath, name)
+        .catch (error) ->
+          console.error(error, error.stack)
     # Clean up removed projects
     projectsToRemove = []
     for rootPath, project of @projectMap

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -102,6 +102,8 @@ module.exports = ProjectView =
         project.onDidChange 'name', ({root, name}) =>
           @updateProjectRoot(root.getPath(), name)
         project.watch()
+      
+      @updateProjectRoot(root.getPath(), project.projectName) if project.projectName
       # Get the project name and update the tree view
       project.findProjectName().then ({root, name}) =>
         @updateProjectRoot(root.getPath(), name)


### PR DESCRIPTION
When we get updated roots, the nodes are replaced and we were updating the old discarded ones. This makes it always update the current one.